### PR TITLE
添加终端mfa认证缓存

### DIFF
--- a/config_example.yml
+++ b/config_example.yml
@@ -30,6 +30,9 @@ BOOTSTRAP_TOKEN: <PleasgeChangeSameWithJumpserver>
 # SSH连接超时时间 (default 15 seconds)
 # SSH_TIMEOUT: 15
 
+# Mfa 认证缓存多少小时(default 1 hour)
+# MFA_AUTH_CACHE_EXPIRE: 1
+
 # 语言 [en,zh]
 # LANGUAGE_CODE: zh
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -50,6 +50,7 @@ type Config struct {
 	ZipTmpPath          string                 `yaml:"ZIP_TMP_PATH"`
 	ClientAliveInterval uint64                 `yaml:"CLIENT_ALIVE_INTERVAL"`
 	RetryAliveCountMax  int                    `yaml:"RETRY_ALIVE_COUNT_MAX"`
+	MfaAuthCacheExpire  time.Duration          `yaml:"MFA_AUTH_CACHE_EXPIRE"`
 
 	ShareRoomType string   `yaml:"SHARE_ROOM_TYPE"`
 	RedisHost     string   `yaml:"REDIS_HOST"`
@@ -131,6 +132,10 @@ func (c *Config) LoadFromEnv() error {
 		case "REDIS_CLUSTERS":
 			clusters := strings.Split(value, ",")
 			c.RedisClusters = clusters
+		case "MFA_AUTH_CACHE_EXPIRE":
+			if num, err := strconv.Atoi(value);err == nil{
+				c.MfaAuthCacheExpire = time.Duration(num)
+			}
 		default:
 			envMap[key] = value
 		}
@@ -186,6 +191,7 @@ var Conf = &Config{
 	RedisHost:           "127.0.0.1",
 	RedisPort:           "6379",
 	RedisPassword:       "",
+	MfaAuthCacheExpire: 1,
 }
 
 func SetConf(conf Config) {


### PR DESCRIPTION
增加koko 使用google 认证mfa时，缓存认证结果，并在一定时长内绕过认证直接登陆。方便使用xshell 或者crt等终端软件在复制ssh会话时的便捷性！！