### PR TITLE
尝试修复快速输入命令后 命令记录丢失的问题

### DIFF
--- a/pkg/proxy/dbparser.go
+++ b/pkg/proxy/dbparser.go
@@ -115,7 +115,7 @@ func (p *DBParser) ParseStream(userInChan chan *model.RoomMessage, srvInChan <-c
 // parseInputState 切换用户输入状态, 并结算命令和结果
 func (p *DBParser) parseInputState(b []byte) []byte {
 	p.inputPreState = p.inputState
-	if bytes.Contains(b, charEnter) {
+	if bytes.LastIndex(b, charEnter) == 0 {
 		// 连续输入enter key, 结算上一条可能存在的命令结果
 		p.sendCommandRecord()
 		p.inputState = false

--- a/pkg/proxy/parser.go
+++ b/pkg/proxy/parser.go
@@ -208,7 +208,7 @@ func (p *Parser) parseInputState(b []byte) []byte {
 		return nil
 	}
 
-	if bytes.Contains(b, charEnter) {
+	if bytes.LastIndex(b, charEnter) == 0 {
 		// 连续输入enter key, 结算上一条可能存在的命令结果
 		p.sendCommandRecord()
 		p.inputState = false

--- a/pkg/utils/terminal.go
+++ b/pkg/utils/terminal.go
@@ -112,6 +112,7 @@ func NewTerminal(c io.ReadWriter, prompt string) *Terminal {
 }
 
 const (
+	keyCtrlC     = 3
 	keyCtrlD     = 4
 	keyCtrlU     = 21
 	keyEnter     = '\r'
@@ -516,6 +517,15 @@ func (t *Terminal) handleKey(key rune) (line string, ok bool) {
 				t.setLine(runes, len(runes))
 			}
 		}
+	case keyCtrlC:
+		t.moveCursorToPos(len(t.line))
+		t.queue([]rune("\r\n"))
+		t.line = []rune{}
+		ok = true
+		t.pos = 0
+		t.cursorX = 0
+		t.cursorY = 0
+		t.maxLine = 0
 	case keyEnter:
 		t.moveCursorToPos(len(t.line))
 		t.queue([]rune("\r\n"))


### PR DESCRIPTION
PR原因:

测试中发现在终端中快速输入命令有时会导致input数据进入output数据,导致命令记录不全。

在尝试修复过程中发现当快速输入命令时由于某些原因导致enter与输入的字符形成粘粘。

`
	代码中使用 if bytes.Contains(b, charEnter) 进行输入/输出判断。当input中存在字符粘粘情况时无法很好的分隔状态
`
将`if bytes.Contains(b, charEnter)`更改为 `bytes.LastIndex(b, charEnter) == 0` 仅对第一位为enter标识符时切换状态。

实测可以提高命中准确率。