### PR TITLE
fix: 修复多行prompt时的换行问题

### DIFF
--- a/pkg/utils/terminal.go
+++ b/pkg/utils/terminal.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"io"
 	"strconv"
+	"strings"
 	"sync"
 	"unicode/utf8"
 )
@@ -608,16 +609,23 @@ func (t *Terminal) addKeyToLine(key rune) {
 	t.moveCursorToPos(t.pos)
 }
 
-func (t *Terminal) writeLine(line []rune) {
-	for len(line) != 0 {
-		remainingOnLine := t.termWidth - t.cursorX
-		todo := len(line)
-		if todo > remainingOnLine {
-			todo = remainingOnLine
+func (t *Terminal) writeLine(lines []rune) {
+	multiLines := strings.SplitAfter(string(lines), "\n")
+	for i, strline := range multiLines {
+		line := []rune(strline)
+		for len(line) != 0 {
+			remainingOnLine := t.termWidth - t.cursorX
+			todo := len(line)
+			if todo > remainingOnLine {
+				todo = remainingOnLine
+			}
+			t.queue(line[:todo])
+			t.advanceCursor(visualLength(line[:todo]))
+			line = line[todo:]
 		}
-		t.queue(line[:todo])
-		t.advanceCursor(visualLength(line[:todo]))
-		line = line[todo:]
+		if i != len(multiLines)-1 {
+			t.cursorX = 0
+		}
 	}
 }
 


### PR DESCRIPTION
## SSH 登录提示内容输出

### 问题
对于存在多行内容的prompt，由于终端在输出时每80字符进行 wrap，结果导致换行错乱，如下图：
![image](https://user-images.githubusercontent.com/30715970/149289785-96066117-f313-4638-b571-fe5099ff2042.png)

### 测试数据
> JumpServer 是全球首款开源的堡垒机，使用 GNU GPL v2.0 开源协议，是符合 4A 规范的运维安全审计系统。
JumpServer 使用 Python / Django 为主进行开发，遵循 Web 2.0 规范，配备了业界领先的 Web Terminal 方案，交互界面美观、用户体验好。
JumpServer 采纳分布式架构，支持多机房跨区域部署，支持横向扩展，无资产数量及并发限制。
改变世界，从一点点开始。

### 解决后效果
![image](https://user-images.githubusercontent.com/30715970/149291367-327410d8-54ad-414e-af46-ef165f9048d9.png)
