### PR TITLE
调整ssh认证的顺序，公钥认证优先

### DIFF
--- a/pkg/srvconn/ssh.go
+++ b/pkg/srvconn/ssh.go
@@ -32,21 +32,6 @@ type SSHClientOptions struct {
 
 func (cfg *SSHClientOptions) AuthMethods() []gossh.AuthMethod {
 	authMethods := make([]gossh.AuthMethod, 0, 3)
-	if cfg.Password != "" {
-		authMethods = append(authMethods, gossh.Password(cfg.Password))
-	}
-	if cfg.keyboardAuth != nil{
-		authMethods = append(authMethods, gossh.KeyboardInteractive(cfg.keyboardAuth))
-	}
-	if cfg.keyboardAuth == nil && cfg.Password != ""{
-		cfg.keyboardAuth = func(user, instruction string, questions []string, echos []bool) (answers []string, err error) {
-			if len(questions) == 0 {
-				return []string{}, nil
-			}
-			return []string{cfg.Password}, nil
-		}
-		authMethods = append(authMethods, gossh.KeyboardInteractive(cfg.keyboardAuth))
-	}
 
 	if cfg.PrivateKey != "" {
 		var (
@@ -70,6 +55,21 @@ func (cfg *SSHClientOptions) AuthMethods() []gossh.AuthMethod {
 	}
 	if cfg.PrivateAuth != nil {
 		authMethods = append(authMethods, gossh.PublicKeys(cfg.PrivateAuth))
+	}
+	if cfg.Password != "" {
+		authMethods = append(authMethods, gossh.Password(cfg.Password))
+	}
+	if cfg.keyboardAuth != nil {
+		authMethods = append(authMethods, gossh.KeyboardInteractive(cfg.keyboardAuth))
+	}
+	if cfg.keyboardAuth == nil && cfg.Password != "" {
+		cfg.keyboardAuth = func(user, instruction string, questions []string, echos []bool) (answers []string, err error) {
+			if len(questions) == 0 {
+				return []string{}, nil
+			}
+			return []string{cfg.Password}, nil
+		}
+		authMethods = append(authMethods, gossh.KeyboardInteractive(cfg.keyboardAuth))
 	}
 
 	return authMethods


### PR DESCRIPTION
你好，我们在生产环境下的SSH认证采用公钥访问，并且采用fail2ban进行失败访问限制，而koko的认证采用密码优先，这样会产生fail2ban的误报，希望将KOKO认证顺序调整为一般SSH默认顺序（publickey,gssapi-keyex,gssapi-with-mic,password）