### PR TITLE
fix: 修复公钥情况下，通过vscode连接失败的问题

### DIFF
--- a/pkg/auth/ssh.go
+++ b/pkg/auth/ssh.go
@@ -142,7 +142,7 @@ func (d *DirectLoginAssetReq) IsToken() bool {
 }
 
 func (d *DirectLoginAssetReq) User() string {
-	if d.Info.User != nil {
+	if d.IsToken() && d.Info.User != nil {
 		return d.Info.User.Username
 	}
 	return d.Username


### PR DESCRIPTION
在添加公钥的情况下， 通过vscode连接或者或者通过资源名直连会失败
```shell
ssh user@asset_user@xxx.xxx.org@192.168.1.88
```
查看日志发现有报错
![image](https://user-images.githubusercontent.com/21884558/165020535-b411a289-46ed-4a5a-a97f-ef8a44ba7f8e.png)

经调试，发现是某处存在空指针错误，修改了部分koko代码，自测可以成功连接上了
