### PR TITLE
perf: 屏蔽--secure参数，目前redis-cli版本为6.0，暂时用不到

### DIFF
--- a/pkg/proxy/server.go
+++ b/pkg/proxy/server.go
@@ -720,7 +720,6 @@ func (s *Server) getRedisConn(localTunnelAddr *net.TCPAddr) (srvConn *srvconn.Re
 		srvconn.SqlCaCert(s.connOpts.app.Attrs.CaCert),
 		srvconn.SqlClientCert(s.connOpts.app.Attrs.ClientCert),
 		srvconn.SqlCertKey(s.connOpts.app.Attrs.CertKey),
-		srvconn.SqlAllowInvalidCert(s.connOpts.app.Attrs.AllowInvalidCert),
 		srvconn.SqlPtyWin(srvconn.Windows{
 			Width:  s.UserConn.Pty().Window.Width,
 			Height: s.UserConn.Pty().Window.Height,

--- a/pkg/srvconn/conn_redis.go
+++ b/pkg/srvconn/conn_redis.go
@@ -35,7 +35,6 @@ func NewRedisConnection(ops ...SqlOption) (*RedisConn, error) {
 		CaCert:           "",
 		ClientCert:       "",
 		CertKey:          "",
-		AllowInvalidCert: false,
 		win: Windows{
 			Width:  80,
 			Height: 120,
@@ -126,9 +125,6 @@ func (opt *sqlOption) RedisCommandArgs() []string {
 		if opt.ClientCertPath != "" && opt.CertKeyPath != "" {
 			params = append(params, "--cert", opt.ClientCertPath)
 			params = append(params, "--key", opt.CertKeyPath)
-		}
-		if opt.AllowInvalidCert {
-			params = append(params, "--insecure")
 		}
 	}
 	if opt.Username != "" {


### PR DESCRIPTION
perf: 屏蔽--secure参数，目前redis-cli版本为6.0，暂时用不到