### PR TITLE
fix: 修复命令输入解析错误的问题

### DIFF
--- a/pkg/proxy/parser.go
+++ b/pkg/proxy/parser.go
@@ -408,7 +408,7 @@ func (p *Parser) splitCmdStream(b []byte) []byte {
 
 			if i0 != i1 {
 				// 匹配字节' \r'，而不是' \r\n'.
-				// 命令超过一行的情况下，服务器端返回的命令会被截断并在截断处插入' \r',
+				// 命令超过一行的情况下，服务器端返回的命令会在行尾处被截断并在截断处插入' \r',
 				// 因此要去掉' \r'保持命令的完整性.
 				b_copy = append(b_copy[:currentIndex+i0], b_copy[currentIndex+i0+len(sep_newline):]...)
 				currentIndex = currentIndex + i0

--- a/pkg/proxy/parser.go
+++ b/pkg/proxy/parser.go
@@ -407,13 +407,15 @@ func (p *Parser) splitCmdStream(b []byte) []byte {
 			}
 
 			if i0 != i1 {
-				// 匹配字节：' \r'
-				// 命令超过一行的情况下，服务器端返回的命令会被截断并截断处插入' \r'
+				// 匹配字节' \r'，而不是' \r\n'.
+				// 命令超过一行的情况下，服务器端返回的命令会被截断并在截断处插入' \r',
+				// 因此要去掉' \r'保持命令的完整性.
 				b_copy = append(b_copy[:currentIndex+i0], b_copy[currentIndex+i0+len(sep_newline):]...)
 				currentIndex = currentIndex + i0
 			} else {
-				// 匹配字节： ' \r\n'
-				// 批量粘贴命令的情况下会出现回车换行符
+				// 匹配字节： ' \r\n'.
+				// 批量粘贴命令的情况下会出现回车换行符,
+				// 此情况下不需要去掉' \r'.
 				currentIndex = currentIndex + i1 + len(sep_enter)
 			}
 

--- a/pkg/proxy/parser_test.go
+++ b/pkg/proxy/parser_test.go
@@ -1,0 +1,48 @@
+package proxy
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestSplitArr(t *testing.T) {
+	var s0 = "abcdefghijk"
+	var s1 = make([]string, 0)
+	i0 := strings.Index(s0, "a")
+	fmt.Println(append(s1, s0[:i0], s0[i0+len("a"):]))
+}
+
+func TestTabKey(t *testing.T) {
+
+	var b = []byte(`12321 \rb79789 \r\n32789732 \rklsj \r\nklfd \rb78937289`)
+	b_len := len(b)
+	b_copy := make([]byte, b_len)
+	copy(b_copy, b)
+	currentIndex := 0
+	for {
+		i1 := bytes.Index(b_copy[currentIndex:], []byte(" \\r\\n"))
+		i0 := bytes.Index(b_copy[currentIndex:], []byte(" \\r"))
+		if i0 == -1 {
+			break
+		}
+
+		if i0 != i1 {
+			// 匹配字节：' \r'
+			// 命令超过一行的情况下，服务器端返回的命令会被截断并截断处插入' \r'
+			b_copy = append(b_copy[:currentIndex+i0], b_copy[currentIndex+i0+len([]byte(" \\r")):]...)
+			currentIndex = currentIndex + i0
+		} else {
+			// 匹配字节： ' \r\n'
+			// 批量粘贴命令的情况下会出现回车换行符
+			currentIndex = currentIndex + i1 + len([]byte(" \\r\\n"))
+		}
+
+		if currentIndex >= b_len {
+			break
+		}
+	}
+	fmt.Println(string(b))
+	fmt.Println(string(b_copy))
+}


### PR DESCRIPTION
当输入命令行超过一行或者批量粘贴命令的时候，proxy/parser.go: 319 parseCmdInput方法解析命令的输入的时候，采用'\r’分割命令行，这样就会错误的解析到最后那行为用户的输入命令，而不能把多行整体的当成用户最后的一次输入。这样可能会导致依赖这个结果的业务异常，比如说高危命令过滤就会变的失效。

- fix: jumpserver/jumpserver#8897