### PR TITLE
支持 JetBrains 公司产品直连资产

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -45,8 +45,9 @@ type Config struct {
 	RedisDBIndex  int      `mapstructure:"REDIS_DB_ROOM"`
 	RedisClusters []string `mapstructure:"REDIS_CLUSTERS"`
 
-	EnableLocalPortForward bool `mapstructure:"ENABLE_LOCAL_PORT_FORWARD"`
-	EnableVscodeSupport    bool `mapstructure:"ENABLE_VSCODE_SUPPORT"`
+	EnableLocalPortForward   bool `mapstructure:"ENABLE_LOCAL_PORT_FORWARD"`
+	EnableReversePortForward bool `mapstructure:"ENABLE_REVERSE_PORT_FORWARD"`
+	EnableIDESupport         bool `mapstructure:"ENABLE_IDE_SUPPORT"`
 
 	RootPath          string
 	DataFolderPath    string
@@ -125,8 +126,9 @@ func getDefaultConfig() Config {
 		RedisPort:           "6379",
 		RedisPassword:       "",
 
-		EnableLocalPortForward: false,
-		EnableVscodeSupport:    false,
+		EnableLocalPortForward:   false,
+		EnableReversePortForward: false,
+		EnableIDESupport:         false,
 	}
 
 }

--- a/pkg/handler/sftp.go
+++ b/pkg/handler/sftp.go
@@ -34,7 +34,7 @@ func (fs *sftpHandler) Filelist(r *sftp.Request) (sftp.ListerAt, error) {
 		}
 		return fileInfos, err
 	case "Stat":
-		logger.Debug("stat method: ", r.Filepath)
+		logger.Debug("Stat method: ", r.Filepath)
 		fsInfo, err := fs.Stat(r.Filepath)
 		return listerat([]os.FileInfo{fsInfo}), err
 	case "Readlink":
@@ -53,16 +53,19 @@ func (fs *sftpHandler) Filecmd(r *sftp.Request) (err error) {
 	case "Setstat":
 		return
 	case "Rename":
-		logger.Debugf("%s=>%s", r.Filepath, r.Target)
+		logger.Debugf("rename: %s=>%s", r.Filepath, r.Target)
 		return fs.Rename(r.Filepath, r.Target)
 	case "Rmdir":
+		logger.Debugf("rmdir: %s", r.Filepath)
 		err = fs.RemoveDirectory(r.Filepath)
 	case "Remove":
+		logger.Debugf("remove: %s", r.Filepath)
 		err = fs.Remove(r.Filepath)
 	case "Mkdir":
+		logger.Debugf("mkdir: %s", r.Filepath)
 		err = fs.MkdirAll(r.Filepath)
 	case "Symlink":
-		logger.Debugf("%s=>%s", r.Filepath, r.Target)
+		logger.Debugf("symlink: %s=>%s", r.Filepath, r.Target)
 		err = fs.Symlink(r.Filepath, r.Target)
 	default:
 		return
@@ -79,7 +82,7 @@ func (fs *sftpHandler) Filewrite(r *sftp.Request) (io.WriterAt, error) {
 	go func() {
 		<-r.Context().Done()
 		if err := f.Close(); err != nil {
-			logger.Errorf("Remote sftp file %s close err: %s", r.Filepath, err)
+			logger.Errorf("Close remote sftp file %s for write failed err: %s", r.Filepath, err)
 		}
 		logger.Infof("Sftp file write %s done", r.Filepath)
 	}()
@@ -95,7 +98,7 @@ func (fs *sftpHandler) Fileread(r *sftp.Request) (io.ReaderAt, error) {
 	go func() {
 		<-r.Context().Done()
 		if err := f.Close(); err != nil {
-			logger.Errorf("Remote sftp file %s close err: %s", r.Filepath, err)
+			logger.Errorf("Close remote sftp file %s for read failed, err: %s", r.Filepath, err)
 		}
 		logger.Infof("Sftp File read %s done", r.Filepath)
 

--- a/pkg/koko/koko.go
+++ b/pkg/koko/koko.go
@@ -79,14 +79,14 @@ func runTasks(jmsService *service.JMService) {
 	go keepHeartbeat(jmsService)
 }
 
-func NewServer(jmsService *service.JMService) *server {
+func NewServer(jmsService *service.JMService) *Server {
 	terminalConf, err := jmsService.GetTerminalConfig()
 	if err != nil {
 		logger.Fatal(err)
 	}
-	app := server{
+	app := Server{
 		jmsService:    jmsService,
-		vscodeClients: make(map[string]*vscodeReq),
+		ideClients: make(map[string]*IDEClient),
 	}
 	app.UpdateTerminalConfig(terminalConf)
 	go app.run()

--- a/pkg/proxy/server.go
+++ b/pkg/proxy/server.go
@@ -633,7 +633,6 @@ func (s *Server) createAvailableGateWay(domain *model.Domain) (*domainGateway, e
 	return dGateway, nil
 }
 
-// getSSHConn 获取ssh连接
 func (s *Server) getK8sConConn(localTunnelAddr *net.TCPAddr) (srvConn srvconn.ServerConnection, err error) {
 	clusterServer := s.connOpts.app.Attrs.Cluster
 	if localTunnelAddr != nil {
@@ -787,6 +786,7 @@ func (s *Server) getPostgreSQLConn(localTunnelAddr *net.TCPAddr) (srvConn *srvco
 	return
 }
 
+// getSSHConn 获取ssh连接
 func (s *Server) getSSHConn() (srvConn *srvconn.SSHConnection, err error) {
 	loginSystemUser := s.systemUserAuthInfo
 	if s.suFromSystemUserAuthInfo != nil {

--- a/pkg/srvconn/sftpconn.go
+++ b/pkg/srvconn/sftpconn.go
@@ -19,6 +19,7 @@ var errNoSelectAsset = errors.New("please select one of the assets")
 
 type UserSftpConn struct {
 	User *model.User
+	Assets []model.Asset
 	Addr string
 	Dirs map[string]os.FileInfo
 
@@ -226,6 +227,11 @@ func (u *UserSftpConn) List() (res []os.FileInfo, err error) {
 }
 
 func (u *UserSftpConn) ParsePath(path string) (fi os.FileInfo, restPath string) {
+	// add asset hostname as prefix if only one asset
+	if u.Assets != nil && len(u.Assets) == 1 {
+		path = fmt.Sprintf("/%s%s", cleanFolderName(u.Assets[0].Hostname), path)
+	}
+
 	path = strings.TrimPrefix(path, "/")
 	data := strings.Split(path, "/")
 	if len(data) == 1 && data[0] == "" {


### PR DESCRIPTION
修改点：
- 增加对 JetBrains 公司产品的远程开发支持（GoLand、PyCharm、Intellij IDEA、JetBrains Gateway 等）；
- 增加对 PyCharm 中的 SSH Interpreter 的支持；
- 增加直接执行命令，如：`ssh -p 2222 user@root@asset-id@jumpserver 'bash -lc "ls -al"'`
- 增加对正向和反向端口转发能力的支持（增加 `ENABLE_REVERSE_PORT_FORWARD` 环境变量）；
- 调整 sftp 目录，支持直接列出节点上的目录树（去掉资产名）；
- 修改环境变量名（由 `ENABLE_VSCODE_SUPPORT` 改为 `ENABLE_IDE_SUPPORT`）