### PR TITLE
命令存储支持 ElasticSearch 数据流

### DIFF
--- a/pkg/proxy/recorderstorage/es.go
+++ b/pkg/proxy/recorderstorage/es.go
@@ -36,7 +36,7 @@ func (es ESCommandStorage) BulkSave(commands []*model.Command) (err error) {
 		return err
 	}
 	for _, item := range commands {
-		meta := []byte(fmt.Sprintf(`{ "index" : { } }%s`, "\n"))
+		meta := []byte(fmt.Sprintf(`{ "create" : { } }%s`, "\n"))
 		data, err := json.Marshal(item)
 		if err != nil {
 			logger.Errorf("ES marshal data to json err: %s", err)
@@ -115,6 +115,6 @@ type bulkResponse struct {
 					Reason string `json:"reason"`
 				} `json:"caused_by"`
 			} `json:"error"`
-		} `json:"index"`
+		} `json:"create"`
 	} `json:"items"`
 }

--- a/pkg/proxy/recorderstorage/es.go
+++ b/pkg/proxy/recorderstorage/es.go
@@ -10,8 +10,8 @@ import (
 
 	"github.com/elastic/go-elasticsearch/v6"
 
-	"github.com/jumpserver/koko/pkg/logger"
 	"github.com/jumpserver/koko/pkg/jms-sdk-go/model"
+	"github.com/jumpserver/koko/pkg/logger"
 )
 
 type ESCommandStorage struct {
@@ -19,6 +19,7 @@ type ESCommandStorage struct {
 	Index   string
 	DocType string
 
+	IsDataStream       bool
 	InsecureSkipVerify bool
 }
 
@@ -35,8 +36,12 @@ func (es ESCommandStorage) BulkSave(commands []*model.Command) (err error) {
 		logger.Errorf("ES new client err: %s", err)
 		return err
 	}
+	action := "index"
+	if es.IsDataStream {
+		action = "create"
+	}
 	for _, item := range commands {
-		meta := []byte(fmt.Sprintf(`{ "create" : { } }%s`, "\n"))
+		meta := []byte(fmt.Sprintf(`{ "%s" : { } }%s`, action, "\n"))
 		data, err := json.Marshal(item)
 		if err != nil {
 			logger.Errorf("ES marshal data to json err: %s", err)
@@ -76,14 +81,14 @@ func (es ESCommandStorage) BulkSave(commands []*model.Command) (err error) {
 		logger.Errorf("ES failure to parse response body: %s", err)
 	} else {
 		for _, d := range blk.Items {
-			if d.Index.Status > 201 {
+			if d[action].Status > 201 {
 				numErrors++
 				logger.Errorf("ES failure to save: [%d]: %s: %s: %s: %s",
-					d.Index.Status,
-					d.Index.Error.Type,
-					d.Index.Error.Reason,
-					d.Index.Error.Cause.Type,
-					d.Index.Error.Cause.Reason,
+					d[action].Status,
+					d[action].Error.Type,
+					d[action].Error.Reason,
+					d[action].Error.Cause.Type,
+					d[action].Error.Cause.Reason,
 				)
 			} else {
 				numIndexed++
@@ -99,22 +104,22 @@ func (es ESCommandStorage) TypeName() string {
 	return "es"
 }
 
+type bulkActionResponse struct {
+	ID     string `json:"_id"`
+	Result string `json:"result"`
+	Status int    `json:"status"`
+	Error  struct {
+		Type   string `json:"type"`
+		Reason string `json:"reason"`
+		Cause  struct {
+			Type   string `json:"type"`
+			Reason string `json:"reason"`
+		} `json:"caused_by"`
+	} `json:"error"`
+}
+
 // https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-bulk.html#bulk-api-response-body
 type bulkResponse struct {
-	Errors bool `json:"errors"`
-	Items  []struct {
-		Index struct {
-			ID     string `json:"_id"`
-			Result string `json:"result"`
-			Status int    `json:"status"`
-			Error  struct {
-				Type   string `json:"type"`
-				Reason string `json:"reason"`
-				Cause  struct {
-					Type   string `json:"type"`
-					Reason string `json:"reason"`
-				} `json:"caused_by"`
-			} `json:"error"`
-		} `json:"create"`
-	} `json:"items"`
+	Errors bool                             `json:"errors"`
+	Items  []map[string]*bulkActionResponse `json:"items"`
 }

--- a/pkg/proxy/recorderstorage/es_test.go
+++ b/pkg/proxy/recorderstorage/es_test.go
@@ -1,0 +1,32 @@
+package recorderstorage
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+)
+
+func TestEsIndexResponse(t *testing.T) {
+	respBodys := [][2]string{
+		{"index", `{"took":24,"errors":false,"items":[{"index":{"_index":"jumpserver-test-1","_type":"_doc","_id":"mo9R9IkBIDTIizd_N0BL","_version":1,"result":"created","_shards":{"total":1,"successful":1,"failed":0},"_seq_no":3,"_primary_term":1,"status":201}},{"index":{"_index":"jumpserver-test-1","_type":"_doc","_id":"m49R9IkBIDTIizd_N0BL","_version":1,"result":"created","_shards":{"total":1,"successful":1,"failed":0},"_seq_no":4,"_primary_term":1,"status":201}}]}`},
+		{"create", `{"took":36,"errors":false,"items":[{"create":{"_index":"jumpserver-test-1","_type":"_doc","_id":"mI9Q9IkBIDTIizd_5UBF","_version":1,"result":"created","_shards":{"total":1,"successful":1,"failed":0},"_seq_no":1,"_primary_term":1,"status":201}},{"create":{"_index":"jumpserver-test-1","_type":"_doc","_id":"mY9Q9IkBIDTIizd_5UBF","_version":1,"result":"created","_shards":{"total":1,"successful":1,"failed":0},"_seq_no":2,"_primary_term":1,"status":201}}]}`},
+	}
+
+	for idx := range respBodys {
+		action, data := respBodys[idx][0], respBodys[idx][1]
+		var (
+			blk  *bulkResponse
+			body bytes.Buffer = *bytes.NewBufferString(data)
+		)
+
+		if err := json.NewDecoder(&body).Decode(&blk); err != nil {
+			t.Fatalf("ES failure to parse response body: %s", err)
+		} else {
+			for _, d := range blk.Items {
+				if _, ok := d[action]; !ok {
+					t.Fatalf("can not get action response from es bulk response body %d", idx)
+				}
+			}
+		}
+	}
+}

--- a/pkg/proxy/util.go
+++ b/pkg/proxy/util.go
@@ -156,7 +156,7 @@ func NewCommandStorage(jmsService *service.JMService, conf *model.TerminalConfig
 		'DOC_TYPE': 'command',
 		  'HOSTS': ['http://172.16.10.122:9200'],
 		  'INDEX': 'jumpserver',
-		  'OTHER': {'IGNORE_VERIFY_CERTS': True},
+		  'OTHER': {'IGNORE_VERIFY_CERTS': True, 'IS_INDEX_DATASTREAM': True},
 		  'TYPE': 'es'
 		}
 	*/
@@ -167,11 +167,15 @@ func NewCommandStorage(jmsService *service.JMService, conf *model.TerminalConfig
 			hosts[i] = item.(string)
 		}
 		var skipVerify bool
+		var isDataStream bool
 		index := cf["INDEX"].(string)
 		docType := cf["DOC_TYPE"].(string)
 		if otherMap, ok := cf["OTHER"].(map[string]interface{}); ok {
 			if insecureSkipVerify, ok := otherMap["IGNORE_VERIFY_CERTS"]; ok {
 				skipVerify = insecureSkipVerify.(bool)
+			}
+			if isIndexDataStream, ok := otherMap["IS_INDEX_DATASTREAM"]; ok {
+				isDataStream = isIndexDataStream.(bool)
 			}
 		}
 		if index == "" {
@@ -184,6 +188,7 @@ func NewCommandStorage(jmsService *service.JMService, conf *model.TerminalConfig
 			Hosts:              hosts,
 			Index:              index,
 			DocType:            docType,
+			IsDataStream:       isDataStream,
 			InsecureSkipVerify: skipVerify,
 		}
 	case "null":


### PR DESCRIPTION
将命令存储索引指向数据流后，发生异常，无法写入
```
[ERRO] ES failure to save: [400]: illegal_argument_exception: only write ops with an op_type of create are allowed in data streams: : 
```
这是因为数据流只支持使用 create 方法写入，而 [代码中](https://github.com/jumpserver/koko/blob/dev/pkg/proxy/recorderstorage/es.go#L39C34-L39C39) 使用的是 index 方法  
将 index 改为 create 后即可支持数据流写入，并且无需修改查询部分

数据流详情参考： https://www.elastic.co/guide/en/elasticsearch/reference/7.16/data-streams.html

PS: 如果兼容 create 方法，命令存储就能兼容一些云商的 ElasticSearch Serverless 服务，~~_能省不少钱_~~