### PR TITLE
fix: 获取正确的SFTP根路径

### DIFF
--- a/pkg/srvconn/sftp_asset.go
+++ b/pkg/srvconn/sftp_asset.go
@@ -523,7 +523,7 @@ func (ad *AssetDir) GetSFTPAndRealPath(su *model.PermAccount, path string) (conn
 	}
 
 	platform := conn.token.Platform
-	sftpRoot := platform.Protocols.GetSftpPath(model.ProtocolSSH)
+	sftpRoot := platform.Protocols.GetSftpPath(model.ProtocolSFTP)
 	accountUsername := su.Username
 	username := ad.user.Username
 	switch strings.ToLower(sftpRoot) {


### PR DESCRIPTION
https://github.com/jumpserver/jumpserver/pull/11091 已将SFTP协议独立，SFTP根目录配置已归属于SFTP协议下

https://github.com/jumpserver/koko/pull/1157 没有改全，仍尝试获取SSH协议下`sftp_home`配置，最后fallback到`/tmp`目录，因而无法正确设置SFTP根目录