### PR TITLE
 fix:  template params escape  by shell interpreter

### DIFF
--- a/cmd/helm/helm.go
+++ b/cmd/helm/helm.go
@@ -1,9 +1,7 @@
 package main
 
 import (
-	"fmt"
 	"os"
-	"strings"
 
 	"github.com/jumpserver/koko/pkg/utils"
 )
@@ -13,21 +11,15 @@ const (
 )
 
 func main() {
-	args := os.Args[1:]
-	var s strings.Builder
-	for i := range args {
-		s.WriteString(args[i])
-		s.WriteString(" ")
-	}
 
-	commandPrefix := commandName
+	var  args []string
+
 	token, _ := utils.GetDecryptedToken()
 	if token != "" {
-		token = strings.ReplaceAll(token, "'", "")
-		commandPrefix = fmt.Sprintf(`%s --kube-token='%s'`, commandName, token)
+		args = append([]string{"--token", token}, os.Args[1:]...)
+	}else{
+		args = os.Args[1:]
 	}
 
-	commandString := fmt.Sprintf("%s %s", commandPrefix, s.String())
-
-	utils.WrappedExec(commandString, token)
+	utils.WrappedExec(commandName, args, token)
 }

--- a/cmd/kubectl/kubectl.go
+++ b/cmd/kubectl/kubectl.go
@@ -1,9 +1,7 @@
 package main
 
 import (
-	"fmt"
 	"os"
-	"strings"
 
 	"github.com/jumpserver/koko/pkg/utils"
 )
@@ -13,20 +11,15 @@ const (
 )
 
 func main() {
-	args := os.Args[1:]
-	var s strings.Builder
-	for i := range args {
-		s.WriteString(args[i])
-		s.WriteString(" ")
-	}
-	commandPrefix := commandName
+
+	var  args []string
+
 	token, _ := utils.GetDecryptedToken()
 	if token != "" {
-		token = strings.ReplaceAll(token, "'", "")
-		commandPrefix = fmt.Sprintf(`%s --token='%s'`, commandName, token)
+		args = append([]string{"--token", token}, os.Args[1:]...)
+	}else{
+		args = os.Args[1:]
 	}
 
-	commandString := fmt.Sprintf("%s %s", commandPrefix, s.String())
-
-	utils.WrappedExec(commandString, token)
+	utils.WrappedExec(commandName, args, token)
 }

--- a/pkg/utils/k8scmd_wrapper.go
+++ b/pkg/utils/k8scmd_wrapper.go
@@ -24,7 +24,7 @@ func GetDecryptedToken() (token string, err error) {
 	return
 }
 
-func WrappedExec(commandString string, secretToHide string) {
+func WrappedExec(command string, args []string, secretToHide string) {
 	gracefulStop := make(chan os.Signal, 1)
 	// Ctrl + C 中断操作特殊处理，防止命令无法终止
 	signal.Notify(gracefulStop, os.Interrupt)
@@ -35,7 +35,7 @@ func WrappedExec(commandString string, secretToHide string) {
 		os.Exit(1)
 	}()
 
-	c := exec.Command("bash", "-c", commandString)
+	c := exec.Command(command, args...)
 	c.Stdin, c.Stdout = os.Stdin, os.Stdout
 	stderr, err := c.StderrPipe()
 	if err != nil {


### PR DESCRIPTION
- Replace string concatenation with proper args handling
- Remove shell execution via bash -c
- Unify helm and kubectl command handling