### PR TITLE
修复了koko组件中，websocket连接存在的部分字节丢失的问题

### DIFF
--- a/pkg/proxy/k8s_test.go
+++ b/pkg/proxy/k8s_test.go
@@ -66,13 +66,13 @@ func TestK8sTreeGen_SpeedTest(t *testing.T) {
 	for i := 0; i <= 100; i++ {
 		v1(mockedData)
 	}
-	duration1 = time.Now().Sub(st1).Milliseconds()
+	duration1 = time.Since(st1).Milliseconds()
 
 	st2 := time.Now()
 	for i := 0; i <= 100; i++ {
 		v2(mockedData)
 	}
-	duration2 = time.Now().Sub(st2).Milliseconds()
+	duration2 = time.Since(st2).Milliseconds()
 
 	fmt.Printf("v1: %d\n", duration1/100)
 	fmt.Printf("v2: %d\n", duration2/100)


### PR DESCRIPTION
在实际使用中，偶尔出现命令不换行以及其他一些显示问题。
经过排查，原有代码中存在两点问题，已修复。