### PR TITLE
feat: supprt config api http request timeout

### DIFF
--- a/config_example.yml
+++ b/config_example.yml
@@ -23,6 +23,9 @@ BOOTSTRAP_TOKEN: <PleasgeChangeSameWithJumpserver>
 # SSH连接超时时间 (default 15 seconds)
 # SSH_TIMEOUT: 15
 
+# Api Http请求的超时时间 (default 30 seconds)
+# HTTP_REQUEST_TIMEOUT: 30
+
 # 语言 [en,zh]
 # LANGUAGE_CODE: zh
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -19,13 +19,14 @@ var (
 )
 
 type Config struct {
-	Name           string `mapstructure:"NAME"`
-	CoreHost       string `mapstructure:"CORE_HOST"`
-	BootstrapToken string `mapstructure:"BOOTSTRAP_TOKEN"`
-	BindHost       string `mapstructure:"BIND_HOST"`
-	SSHPort        string `mapstructure:"SSHD_PORT"`
-	HTTPPort       string `mapstructure:"HTTPD_PORT"`
-	SSHTimeout     int    `mapstructure:"SSH_TIMEOUT"`
+	Name               string `mapstructure:"NAME"`
+	CoreHost           string `mapstructure:"CORE_HOST"`
+	BootstrapToken     string `mapstructure:"BOOTSTRAP_TOKEN"`
+	BindHost           string `mapstructure:"BIND_HOST"`
+	SSHPort            string `mapstructure:"SSHD_PORT"`
+	HTTPPort           string `mapstructure:"HTTPD_PORT"`
+	SSHTimeout         int    `mapstructure:"SSH_TIMEOUT"`
+	HttpRequestTimeout int    `mapstructure:"HTTP_REQUEST_TIMEOUT"`
 
 	LogLevel string `mapstructure:"LOG_LEVEL"`
 
@@ -125,23 +126,24 @@ func getDefaultConfig() Config {
 		}
 	}
 	return Config{
-		Name:              defaultName,
-		CoreHost:          "http://localhost:8080",
-		BootstrapToken:    "",
-		BindHost:          "0.0.0.0",
-		SSHPort:           "2222",
-		SSHTimeout:        15,
-		HTTPPort:          "5000",
-		AccessKeyFilePath: accessKeyFilePath,
-		LogLevel:          "INFO",
-		RootPath:          rootPath,
-		DataFolderPath:    dataFolderPath,
-		LogDirPath:        LogDirPath,
-		KeyFolderPath:     keyFolderPath,
-		ReplayFolderPath:  replayFolderPath,
-		FTPFileFolderPath: ftpFileFolderPath,
-		CertsFolderPath:   CertsFolderPath,
-		LanguageCode:      "en",
+		Name:               defaultName,
+		CoreHost:           "http://localhost:8080",
+		BootstrapToken:     "",
+		BindHost:           "0.0.0.0",
+		SSHPort:            "2222",
+		SSHTimeout:         15,
+		HttpRequestTimeout: 30,
+		HTTPPort:           "5000",
+		AccessKeyFilePath:  accessKeyFilePath,
+		LogLevel:           "INFO",
+		RootPath:           rootPath,
+		DataFolderPath:     dataFolderPath,
+		LogDirPath:         LogDirPath,
+		KeyFolderPath:      keyFolderPath,
+		ReplayFolderPath:   replayFolderPath,
+		FTPFileFolderPath:  ftpFileFolderPath,
+		CertsFolderPath:    CertsFolderPath,
+		LanguageCode:       "en",
 
 		Comment:             "KOKO",
 		UploadFailedReplay:  true,

--- a/pkg/koko/koko.go
+++ b/pkg/koko/koko.go
@@ -95,8 +95,9 @@ func runTasks(jmsService *service.JMService) {
 
 func MustJMService() *service.JMService {
 	key := MustLoadValidAccessKey()
-	jmsService, err := service.NewAuthJMService(service.JMSCoreHost(
-		config.GlobalConfig.CoreHost), service.JMSTimeOut(30*time.Second),
+	jmsService, err := service.NewAuthJMService(
+		service.JMSCoreHost(config.GlobalConfig.CoreHost),
+		service.JMSTimeOut(time.Duration(config.GlobalConfig.HttpRequestTimeout)*time.Second),
 		service.JMSAccessKey(key.ID, key.Secret),
 	)
 	if err != nil {


### PR DESCRIPTION
目前我司正在使用社区版本的jumpserver，但是我们的机器规格较小，在登录时会发生以下问题：
1. 用户在终端中使用公私钥进行登录
2. koko向core发起认证请求
3. core无法在30s内完成
4. koko侧配置http请求的超时时间为硬编码30s，客户端请求超时，认证方式退化到密码认证

我们当前使用的版本较老，为v2.28.6。但是我觉得这个配置应该也开放给用户，供性能有限的用户能够使用公私钥登录