### PR TITLE
fix(auth): allow token SSH login when password auth is disabled

### DIFF
--- a/pkg/auth/ssh.go
+++ b/pkg/auth/ssh.go
@@ -221,6 +221,10 @@ const (
 	tokenPrefix = "JMS-"
 )
 
+func IsTokenLoginUsername(username string) bool {
+	return strings.HasPrefix(username, tokenPrefix)
+}
+
 const (
 	sshProtocolLen  = 3
 	withProtocolLen = 4
@@ -288,7 +292,7 @@ func parseDirectLoginReq(jmsService *service.JMService, ctx ssh.Context) (*Direc
 }
 
 func parseJMSTokenLoginReq(jmsService *service.JMService, ctx ssh.Context) (*DirectLoginAssetReq, bool) {
-	if strings.HasPrefix(ctx.User(), tokenPrefix) {
+	if IsTokenLoginUsername(ctx.User()) {
 		token := strings.TrimPrefix(ctx.User(), tokenPrefix)
 		key := cache.CreateAddrCacheKey(ctx.RemoteAddr(), token)
 		if connectToken := cache.TokenCacheInstance.Get(key); connectToken != nil {

--- a/pkg/handler/server_ssh.go
+++ b/pkg/handler/server_ssh.go
@@ -36,7 +36,7 @@ const ctxID = "ctxID"
 func (s *Server) PasswordAuth(ctx ssh.Context, password string) error {
 	ctx.SetValue(ctxID, ctx.SessionID())
 	tConfig := s.GetTerminalConfig()
-	if !tConfig.PasswordAuth {
+	if !tConfig.PasswordAuth && !auth.IsTokenLoginUsername(ctx.User()) {
 		logger.Info("Core API disable password auth")
 		return errors.New("password auth disabled")
 	}


### PR DESCRIPTION
### 背景
关闭 `允许用户通过密码验证登录 koko 组件(TERMINAL_PASSWORD_AUTH )` 后，koko 会在 SSH 密码认证入口直接拒绝所有密码认证请求
导致当用户使用 SSH 客户端方式连接资产时也会被 koko 的密码认证开关提前拦截
查看发现实际使用客户端连接时是以 JMS-<token> 形式的临时连接令牌进行连接认证，koko 中已有判定逻辑

### 修改内容
ssh.go 中新增加了 IsTokenLoginUsername 复用已有的判断 token 前缀判断逻辑
修改了 parseJMSTokenLoginReq 函数中的判定逻辑，改为复用 IsTokenLoginUsername 避免重复判断逻辑
server_ssh.go 中调整了判断逻辑，如果是 token 格式则放行，如果不是则保持原有逻辑