### PR TITLE
修复 sudo su 切换用户时 sudo 密码提示匹配失败导致超时

### DIFF
--- a/pkg/srvconn/conn_ssh_su.go
+++ b/pkg/srvconn/conn_ssh_su.go
@@ -92,7 +92,7 @@ const (
 	 \b: word boundary 即: 匹配某个单词边界
 	*/
 
-	passwordMatchPattern = "(?i)\\bpassword\\b\\s*[:：]|密码\\s*[:：]|password\\s*[:：]\\s*"
+	passwordMatchPattern = `(?i)(?:\[\s*sudo\s*\]\s*)?\bpassword\b(?:\s+for\s+[^\r\n:：]+)?\s*[:：]|密码\s*[:：]`
 
 	usernameMatchPattern = "(?i)username:?\\s*$|name:?\\s*$|用户名:?\\s*$"
 )


### PR DESCRIPTION
当平台提权方式配置为 sudo su - 或者 sudo su ，并执行自动切换用户时：
" [sudo] password for username: "
此类提示不会被sudo逻辑正常匹配，导致sudo切换自功能无法正常执行。
报错 I/O timeout，触发超时逻辑。

<img width="206" height="61" alt="企业微信截图_17810832536355" src="https://github.com/user-attachments/assets/abb019ea-239e-4f1c-b92f-4c2ae8098dd3" />

<img width="170" height="66" alt="企业微信截图_1781083414974" src="https://github.com/user-attachments/assets/972dead9-a651-42ca-82f4-5e0aea0c9aa3" />



优化正则经过测试后可以正常执行原先逻辑。