### PR TITLE
fix: preserve SFTP subsystem exit status

### DIFF
--- a/pkg/handler/server_ssh.go
+++ b/pkg/handler/server_ssh.go
@@ -98,13 +98,18 @@ func (s *Server) SFTPHandler(sess ssh.Session) {
 	reqID := common.UUID()
 	logger.Infof("SFTP request %s: Handler start", reqID)
 	req := sftp.NewRequestServer(sess, handlers)
-	if err := req.Serve(); err == io.EOF {
+	serveErr := req.Serve()
+	if errors.Is(serveErr, io.EOF) {
 		logger.Debugf("SFTP request %s: Exited session.", reqID)
-	} else if err != nil {
-		logger.Errorf("SFTP request %s: Server completed with error %s", reqID, err)
+	} else if serveErr != nil {
+		logger.Errorf("SFTP request %s: Server completed with error %s", reqID, serveErr)
 	}
-	_ = req.Close()
 	sftpHandler.Close()
+	if serveErr != nil && !errors.Is(serveErr, io.EOF) {
+		if err := sess.Exit(1); err != nil {
+			logger.Errorf("SFTP request %s: Send exit status failed: %s", reqID, err)
+		}
+	}
 	logger.Infof("SFTP request %s: Handler exit.", reqID)
 }
 


### PR DESCRIPTION
## Summary

This fixes SFTP subsystem exit-status handling for OpenSSH clients.

Koko passes the SSH session channel directly to `sftp.NewRequestServer(sess, handlers)`. Calling `req.Close()` after `req.Serve()` closes that underlying SSH channel before the SSH subsystem wrapper can send `exit-status 0`.

With OpenSSH `scp` in its default SFTP mode, this can make a successful upload look like a failure: all SFTP file operations return `SSH2_FXP_STATUS 0`, but the client does not receive a normal SSH exit status and exits non-zero.

This change:

- treats `io.EOF` from `req.Serve()` as the normal end of an SFTP session;
- avoids closing the SSH session channel before the subsystem wrapper sends `exit-status 0`;
- explicitly sends `exit-status 1` if `req.Serve()` returns a non-EOF error.

## Verification

- `go test ./pkg/handler`
- Manual verification with OpenSSH `scp` in default SFTP mode: a successful upload now returns exit code `0` and the uploaded file is present on the target account.
