### PR TITLE
修复 SSH Keyboard-Interactive 多阶段二次认证适配

### DIFF
--- a/pkg/proxy/server.go
+++ b/pkg/proxy/server.go
@@ -10,6 +10,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -601,7 +602,7 @@ func (s *Server) getMongoDBConn(localTunnelAddr *net.TCPAddr) (srvConn *srvconn.
 	return
 }
 
-func (s *Server) getSSHConn() (srvConn *srvconn.SSHConnection, err error) {
+func (s *Server) getSSHConn(stopConnecting func()) (srvConn *srvconn.SSHConnection, err error) {
 	loginAccount := s.account.GetBaseAccount()
 	if s.suFromAccount != nil {
 		loginAccount = s.suFromAccount
@@ -628,32 +629,72 @@ func (s *Server) getSSHConn() (srvConn *srvconn.SSHConnection, err error) {
 		}
 	}
 
-	password := loginAccount.Secret
-	kb := srvconn.SSHClientKeyboardAuth(func(user, instruction string,
+	password := ""
+	if !loginAccount.IsSSHKey() {
+		password = loginAccount.Secret
+	}
+	var prepareKeyboardPrompt sync.Once
+	var keyboardPrompted bool
+	kb := srvconn.SSHClientKeyboardAuth(func(_ string, instruction string,
 		questions []string, echos []bool) (answers []string, err error) {
 		s.setKeyBoardMode()
+		defer s.resetKeyboardMode()
+
+		prepareKeyboardPrompt.Do(func() {
+			stopConnecting()
+			utils.IgnoreErrWriteString(s.UserConn, "\r\x1b[2K")
+			if msg := strings.TrimSpace(s.connOpts.ConnectMsg()); msg != "" {
+				utils.IgnoreErrWriteString(s.UserConn, msg+"\r\n")
+			}
+		})
+
 		vt := term.NewTerminal(s.UserConn, "")
-		utils.IgnoreErrWriteString(s.UserConn, "\r\n")
+		pty := s.UserConn.Pty()
+		if pty.Window.Width > 0 && pty.Window.Height > 0 {
+			_ = vt.SetSize(pty.Window.Width, pty.Window.Height)
+		}
+		if text := keyboardInteractiveInstruction(instruction); text != "" {
+			utils.IgnoreErrWriteString(vt, text+"\n")
+		}
+
 		ans := make([]string, len(questions))
 		for i := range questions {
 			q := questions[i]
-			vt.SetPrompt(questions[i])
-			logger.Debugf("Conn[%s] keyboard auth question %d [ %s ]", s.UserConn.ID(), i, q)
-			if strings.Contains(strings.ToLower(q), "password") {
-				if password != "" {
-					ans[i] = password
-					continue
-				}
+			echo := keyboardInteractiveEcho(echos, i)
+			logger.Debugf("Conn[%s] keyboard auth question %d [ %s ], echo: %t",
+				s.UserConn.ID(), i, q, echo)
+			if password != "" && isKeyboardInteractivePasswordQuestion(q) {
+				ans[i] = password
+				continue
 			}
-			line, err2 := vt.ReadLine()
+
+			combinedPasswordMFA := password != "" && isKeyboardInteractiveCombinedPasswordMFAQuestion(q)
+			prompt := keyboardInteractivePrompt(q)
+			if combinedPasswordMFA {
+				prompt = "OTP Code: "
+			}
+			keyboardPrompted = true
+			var line string
+			var err2 error
+			if echo {
+				vt.SetPrompt(prompt)
+				line, err2 = vt.ReadLine()
+			} else {
+				line, err2 = vt.ReadPassword(prompt)
+			}
 			if err2 != nil {
 				logger.Errorf("Conn[%s] keyboard auth read err: %s", s.UserConn.ID(), err2)
+				return nil, err2
 			}
-			ans[i] = line
+			if combinedPasswordMFA {
+				ans[i] = password + line
+			} else {
+				ans[i] = line
+			}
 		}
-		s.resetKeyboardMode()
 		return ans, nil
 	})
+	sshAuthOpts = append(sshAuthOpts, srvconn.SSHClientPreferKeyboardInteractive())
 	sshAuthOpts = append(sshAuthOpts, kb)
 	// 获取网关配置
 	proxyArgs := s.getGatewayProxyOptions()
@@ -665,10 +706,21 @@ func (s *Server) getSSHConn() (srvConn *srvconn.SSHConnection, err error) {
 		logger.Errorf("Get new ssh client err: %s", err)
 		return nil, err
 	}
-	srvconn.AddClientCache(key, sshClient)
+	cacheSSHClient := !keyboardPrompted
+	if cacheSSHClient {
+		srvconn.AddClientCache(key, sshClient)
+	}
+	releaseSSHClient := func() {
+		if cacheSSHClient {
+			srvconn.ReleaseClientCacheKey(key, sshClient)
+			return
+		}
+		_ = sshClient.Close()
+	}
 	sess, err := sshClient.AcquireSession()
 	if err != nil {
 		logger.Errorf("SSH client(%s) start session err %s", sshClient, err)
+		releaseSSHClient()
 		return nil, err
 	}
 
@@ -704,7 +756,7 @@ func (s *Server) getSSHConn() (srvConn *srvconn.SSHConnection, err error) {
 	if err != nil {
 		_ = sess.Close()
 		sshClient.ReleaseSession(sess)
-		srvconn.ReleaseClientCacheKey(key, sshClient)
+		releaseSSHClient()
 		return nil, err
 	}
 	if s.suFromAccount != nil {
@@ -720,7 +772,7 @@ func (s *Server) getSSHConn() (srvConn *srvconn.SSHConnection, err error) {
 		_ = sess.Wait()
 		sshClient.ReleaseSession(sess)
 		logger.Infof("SSH client(%s) shell connection release", sshClient)
-		srvconn.ReleaseClientCacheKey(key, sshClient)
+		releaseSSHClient()
 	}()
 	return sshConn, nil
 }
@@ -848,15 +900,26 @@ func (s *Server) getServerConn(proxyAddr *net.TCPAddr) (srvconn.ServerConnection
 		return s.cacheSSHConnection, nil
 	}
 	done := make(chan struct{})
+	stopped := make(chan struct{})
+	var stopOnce sync.Once
+	stopConnecting := func() {
+		stopOnce.Do(func() {
+			close(done)
+			<-stopped
+		})
+	}
 	defer func() {
+		stopConnecting()
 		utils.IgnoreErrWriteString(s.UserConn, "\r\n")
-		close(done)
 	}()
-	go s.sendConnectingMsg(done)
+	go func() {
+		defer close(stopped)
+		s.sendConnectingMsg(done)
+	}()
 	protocol := s.connOpts.authInfo.Protocol
 	switch protocol {
 	case srvconn.ProtocolSSH:
-		return s.getSSHConn()
+		return s.getSSHConn(stopConnecting)
 	case srvconn.ProtocolTELNET:
 		return s.getTelnetConn()
 	case srvconn.ProtocolK8s:
@@ -877,7 +940,7 @@ func (s *Server) getServerConn(proxyAddr *net.TCPAddr) (srvconn.ServerConnection
 	}
 }
 
-func (s *Server) sendConnectingMsg(done chan struct{}) {
+func (s *Server) sendConnectingMsg(done <-chan struct{}) {
 	delay := 0.0
 	maxDelay := 5 * 60.0 // 最多执行五分钟
 	msg := fmt.Sprintf("%s  %.1f", s.connOpts.ConnectMsg(), delay)

--- a/pkg/proxy/ssh_keyboard_auth.go
+++ b/pkg/proxy/ssh_keyboard_auth.go
@@ -1,0 +1,106 @@
+package proxy
+
+import "strings"
+
+var keyboardInteractiveMFAQuestionMarkers = []string{
+	"otp",
+	"one-time",
+	"one time",
+	"verification code",
+	"verify code",
+	"auth code",
+	"authentication code",
+	"passcode",
+	"token",
+	"dynamic code",
+	"dynamic password",
+	"secondary authentication",
+	"secondary password",
+	"second-factor",
+	"second factor",
+	"two-factor",
+	"two factor",
+	"2fa",
+	"mfa",
+	"验证码",
+	"认证码",
+	"校验码",
+	"动态码",
+	"动态密码",
+	"动态口令",
+	"令牌",
+	"二次认证",
+	"二次验证",
+	"辅助认证",
+	"辅助验证",
+	"双因子",
+}
+
+var keyboardInteractivePasswordQuestionMarkers = []string{
+	"password",
+	"passwd",
+	"密码",
+}
+
+var keyboardInteractiveCombinedQuestionMarkers = []string{
+	"password + otp",
+	"password+otp",
+	"password and otp",
+	"password followed by the otp",
+	"密码 + 动态",
+	"密码+动态",
+	"密码和动态",
+	"密码 + 验证码",
+	"密码+验证码",
+	"密码和验证码",
+}
+
+func isKeyboardInteractiveMFAQuestion(question string) bool {
+	normalized := strings.ToLower(strings.TrimSpace(question))
+	for _, marker := range keyboardInteractiveMFAQuestionMarkers {
+		if strings.Contains(normalized, marker) {
+			return true
+		}
+	}
+	return false
+}
+
+func isKeyboardInteractiveCombinedPasswordMFAQuestion(question string) bool {
+	normalized := strings.ToLower(strings.TrimSpace(question))
+	for _, marker := range keyboardInteractiveCombinedQuestionMarkers {
+		if strings.Contains(normalized, marker) {
+			return true
+		}
+	}
+	return false
+}
+
+func isKeyboardInteractivePasswordQuestion(question string) bool {
+	normalized := strings.ToLower(strings.TrimSpace(question))
+	if normalized == "" || isKeyboardInteractiveMFAQuestion(normalized) {
+		return false
+	}
+	for _, marker := range keyboardInteractivePasswordQuestionMarkers {
+		if strings.Contains(normalized, marker) {
+			return true
+		}
+	}
+	return false
+}
+
+func keyboardInteractiveEcho(echos []bool, index int) bool {
+	return index >= 0 && index < len(echos) && echos[index]
+}
+func keyboardInteractivePrompt(question string) string {
+	prompt := strings.TrimSpace(question)
+	if prompt == "" {
+		return "Authentication response: "
+	}
+	return prompt + " "
+}
+
+func keyboardInteractiveInstruction(instruction string) string {
+	normalized := strings.ReplaceAll(instruction, "\r\n", "\n")
+	normalized = strings.ReplaceAll(normalized, "\r", "\n")
+	return strings.TrimSpace(normalized)
+}

--- a/pkg/proxy/ssh_keyboard_auth_test.go
+++ b/pkg/proxy/ssh_keyboard_auth_test.go
@@ -1,0 +1,97 @@
+package proxy
+
+import "testing"
+
+func TestIsKeyboardInteractivePasswordQuestion(t *testing.T) {
+	tests := []struct {
+		name     string
+		question string
+		want     bool
+	}{
+		{name: "english password", question: "Password: ", want: true},
+		{name: "english passwd", question: "Enter passwd", want: true},
+		{name: "chinese password", question: "请输入密码：", want: true},
+		{name: "otp", question: "OTP Code: ", want: false},
+		{name: "combined password otp", question: "Password + OTP: ", want: false},
+		{name: "combined chinese", question: "请输入密码和动态口令：", want: false},
+		{name: "verification code", question: "Verification code: ", want: false},
+		{name: "sangfor secondary password", question: "Secondary Authentication Password: ", want: false},
+		{name: "chinese secondary verification", question: "请输入辅助验证密码：", want: false},
+		{name: "token", question: "Token: ", want: false},
+		{name: "empty", question: "", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isKeyboardInteractivePasswordQuestion(tt.question); got != tt.want {
+				t.Fatalf("isKeyboardInteractivePasswordQuestion(%q) = %v, want %v",
+					tt.question, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsKeyboardInteractiveCombinedPasswordMFAQuestion(t *testing.T) {
+	tests := []struct {
+		question string
+		want     bool
+	}{
+		{question: "Password + OTP: ", want: true},
+		{question: "请输入密码和动态口令：", want: true},
+		{question: "Secondary Authentication Password: ", want: false},
+		{question: "请输入辅助验证密码：", want: false},
+		{question: "Password: ", want: false},
+		{question: "OTP Code: ", want: false},
+	}
+	for _, tt := range tests {
+		if got := isKeyboardInteractiveCombinedPasswordMFAQuestion(tt.question); got != tt.want {
+			t.Fatalf("isKeyboardInteractiveCombinedPasswordMFAQuestion(%q) = %v, want %v",
+				tt.question, got, tt.want)
+		}
+	}
+}
+
+func TestKeyboardInteractiveEcho(t *testing.T) {
+	echos := []bool{true, false}
+	if !keyboardInteractiveEcho(echos, 0) {
+		t.Fatal("expected first question to echo")
+	}
+	if keyboardInteractiveEcho(echos, 1) {
+		t.Fatal("expected second question not to echo")
+	}
+	if keyboardInteractiveEcho(echos, 2) {
+		t.Fatal("missing echo value must default to false")
+	}
+}
+func TestKeyboardInteractivePrompt(t *testing.T) {
+	tests := []struct {
+		question string
+		want     string
+	}{
+		{question: "  Secondary Authentication Password: \r\n", want: "Secondary Authentication Password: "},
+		{question: "OTP Code:", want: "OTP Code: "},
+		{question: "  Verification code:  ", want: "Verification code: "},
+		{question: "", want: "Authentication response: "},
+	}
+	for _, tt := range tests {
+		if got := keyboardInteractivePrompt(tt.question); got != tt.want {
+			t.Fatalf("keyboardInteractivePrompt(%q) = %q, want %q", tt.question, got, tt.want)
+		}
+	}
+}
+func TestKeyboardInteractiveInstruction(t *testing.T) {
+	tests := []struct {
+		instruction string
+		want        string
+	}{
+		{instruction: "  Verify identity  ", want: "Verify identity"},
+		{instruction: "First line\r\nSecond line\r\n", want: "First line\nSecond line"},
+		{instruction: "First line\rSecond line", want: "First line\nSecond line"},
+		{instruction: "\r\n\t", want: ""},
+	}
+	for _, tt := range tests {
+		if got := keyboardInteractiveInstruction(tt.instruction); got != tt.want {
+			t.Fatalf("keyboardInteractiveInstruction(%q) = %q, want %q", tt.instruction, got, tt.want)
+		}
+	}
+}

--- a/pkg/srvconn/ssh.go
+++ b/pkg/srvconn/ssh.go
@@ -18,15 +18,16 @@ import (
 type SSHClientOption func(conf *SSHClientOptions)
 
 type SSHClientOptions struct {
-	Host         string
-	Port         string
-	Username     string
-	Password     string
-	PrivateKey   string
-	Passphrase   string
-	Timeout      int
-	keyboardAuth gossh.KeyboardInteractiveChallenge
-	PrivateAuth  gossh.Signer
+	Host                      string
+	Port                      string
+	Username                  string
+	Password                  string
+	PrivateKey                string
+	Passphrase                string
+	Timeout                   int
+	keyboardAuth              gossh.KeyboardInteractiveChallenge
+	preferKeyboardInteractive bool
+	PrivateAuth               gossh.Signer
 
 	proxySSHClientOptions []SSHClientOptions
 }
@@ -57,10 +58,13 @@ func (cfg *SSHClientOptions) AuthMethods() []gossh.AuthMethod {
 	if cfg.PrivateAuth != nil {
 		authMethods = append(authMethods, gossh.PublicKeys(cfg.PrivateAuth))
 	}
+	if cfg.preferKeyboardInteractive && cfg.keyboardAuth != nil {
+		authMethods = append(authMethods, gossh.KeyboardInteractive(cfg.keyboardAuth))
+	}
 	if cfg.Password != "" {
 		authMethods = append(authMethods, gossh.Password(cfg.Password))
 	}
-	if cfg.keyboardAuth != nil {
+	if !cfg.preferKeyboardInteractive && cfg.keyboardAuth != nil {
 		authMethods = append(authMethods, gossh.KeyboardInteractive(cfg.keyboardAuth))
 	}
 	if cfg.keyboardAuth == nil && cfg.Password != "" {
@@ -133,6 +137,13 @@ func SSHClientProxyClient(proxyArgs ...SSHClientOptions) SSHClientOption {
 func SSHClientKeyboardAuth(keyboardAuth gossh.KeyboardInteractiveChallenge) SSHClientOption {
 	return func(conf *SSHClientOptions) {
 		conf.keyboardAuth = keyboardAuth
+	}
+}
+
+// SSHClientPreferKeyboardInteractive prioritizes an explicit interactive callback over password auth.
+func SSHClientPreferKeyboardInteractive() SSHClientOption {
+	return func(conf *SSHClientOptions) {
+		conf.preferKeyboardInteractive = true
 	}
 }
 

--- a/pkg/srvconn/ssh_auth_test.go
+++ b/pkg/srvconn/ssh_auth_test.go
@@ -1,0 +1,142 @@
+//go:build linux
+
+package srvconn
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"errors"
+	"net"
+	"reflect"
+	"testing"
+	"time"
+
+	gossh "golang.org/x/crypto/ssh"
+)
+
+func TestSSHClientAuthMethodOrder(t *testing.T) {
+	tests := []struct {
+		name             string
+		explicitCallback bool
+		prefer           bool
+		want             []string
+	}{
+		{
+			name: "password-only callers retain automatic fallback",
+			want: []string{"password", "keyboard-interactive"},
+		},
+		{
+			name:             "explicit callback keeps password first by default",
+			explicitCallback: true,
+			want:             []string{"password", "keyboard-interactive"},
+		},
+		{
+			name:             "keyboard interactive can be explicitly preferred",
+			explicitCallback: true,
+			prefer:           true,
+			want:             []string{"keyboard-interactive"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &SSHClientOptions{}
+			SSHClientPassword("asset-password")(cfg)
+			if tt.explicitCallback {
+				SSHClientKeyboardAuth(func(_ string, _ string, _ []string, _ []bool) ([]string, error) {
+					return []string{"asset-password"}, nil
+				})(cfg)
+			}
+			if tt.prefer {
+				SSHClientPreferKeyboardInteractive()(cfg)
+			}
+
+			if got := authenticateAndRecordOrder(t, cfg.AuthMethods(), true, false); !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("authentication order = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPreferredKeyboardInteractiveFallsBackToPassword(t *testing.T) {
+	cfg := &SSHClientOptions{}
+	SSHClientPassword("asset-password")(cfg)
+	SSHClientKeyboardAuth(func(_ string, _ string, _ []string, _ []bool) ([]string, error) {
+		return []string{"asset-password"}, nil
+	})(cfg)
+	SSHClientPreferKeyboardInteractive()(cfg)
+
+	want := []string{"password"}
+	if got := authenticateAndRecordOrder(t, cfg.AuthMethods(), false, true); !reflect.DeepEqual(got, want) {
+		t.Fatalf("authentication order = %v, want %v", got, want)
+	}
+}
+
+func authenticateAndRecordOrder(t *testing.T, authMethods []gossh.AuthMethod, keyboardAvailable, acceptPassword bool) []string {
+	t.Helper()
+
+	_, privateKey, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate host key: %v", err)
+	}
+	hostSigner, err := gossh.NewSignerFromKey(privateKey)
+	if err != nil {
+		t.Fatalf("create host signer: %v", err)
+	}
+
+	var attempts []string
+	serverConfig := &gossh.ServerConfig{
+		PasswordCallback: func(_ gossh.ConnMetadata, _ []byte) (*gossh.Permissions, error) {
+			attempts = append(attempts, "password")
+			if acceptPassword {
+				return nil, nil
+			}
+			return nil, errors.New("password rejected to test fallback")
+		},
+	}
+	if keyboardAvailable {
+		serverConfig.KeyboardInteractiveCallback = func(_ gossh.ConnMetadata, challenge gossh.KeyboardInteractiveChallenge) (*gossh.Permissions, error) {
+			attempts = append(attempts, "keyboard-interactive")
+			answers, challengeErr := challenge("", "", []string{"Password: "}, []bool{false})
+			if challengeErr != nil {
+				return nil, challengeErr
+			}
+			if len(answers) != 1 || answers[0] != "asset-password" {
+				return nil, errors.New("unexpected keyboard-interactive answer")
+			}
+			return nil, nil
+		}
+	}
+	serverConfig.AddHostKey(hostSigner)
+
+	serverConn, clientConn := net.Pipe()
+	deadline := time.Now().Add(5 * time.Second)
+	_ = serverConn.SetDeadline(deadline)
+	_ = clientConn.SetDeadline(deadline)
+
+	serverErr := make(chan error, 1)
+	go func() {
+		conn, _, _, serverHandshakeErr := gossh.NewServerConn(serverConn, serverConfig)
+		if conn != nil {
+			_ = conn.Close()
+		}
+		serverErr <- serverHandshakeErr
+	}()
+
+	clientConfig := &gossh.ClientConfig{
+		User:            "asset-user",
+		Auth:            authMethods,
+		HostKeyCallback: gossh.InsecureIgnoreHostKey(),
+	}
+	conn, _, _, clientErr := gossh.NewClientConn(clientConn, "pipe", clientConfig)
+	if conn != nil {
+		_ = conn.Close()
+	}
+	if clientErr != nil {
+		t.Fatalf("client handshake failed: %v", clientErr)
+	}
+	if err = <-serverErr; err != nil {
+		t.Fatalf("server handshake failed: %v", err)
+	}
+	return attempts
+}


### PR DESCRIPTION
## 问题背景

部分受 EDR 或 OTP 保护的 SSH 资产通过 Keyboard-Interactive 完成二次认证。Koko 在交互式资产连接过程中未正确处理多阶段认证问题，可能直接返回认证失败，无法向用户显示二次认证输入提示。

## 修改内容

- 仅为 Koko 交互式资产会话优先使用 Keyboard-Interactive
- 保持其他 SSH 调用方原有的 Password 优先顺序
- 支持多个 Keyboard-Interactive 问题及服务端 echo 标志
- 自动填写普通密码问题，并向用户显示 OTP、Token 等二次认证问题
- SSH Key 账号不会把私钥内容作为密码回答
- 在显示认证问题前停止连接计时输出，修复提示格式和缩进
- 用户实际输入过二次认证信息的 SSH 客户端不进入连接复用缓存
- 完善输入异常处理及 Keyboard Mode 状态恢复

## 兼容性

- Password-only SSH 服务仍可回退到 Password 认证
- SSH Key + OTP 场景支持用户输入二次认证信息
- 普通 Password、SSH Key 登录行为保持不变
- SFTP、VSCode、端口转发及非交互命令路径保持现有行为

## 验证

- `git apply --check` 通过
- `git diff --check` 通过
- Keyboard-Interactive 辅助逻辑测试通过
- Linux/AMD64 全仓库构建通过
- `pkg/proxy` Linux 测试二进制编译通过
- `pkg/srvconn` Linux 测试二进制编译通过
- Linux/AMD64 环境下 `go vet ./...` 通过
- JumpServer v4.10.16 企业版环境完成 Keyboard-Interactive 二次认证场景验证